### PR TITLE
Handle the 0x exception

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -88,6 +88,10 @@ export default async function aggregate(calls, config) {
   const blockNumber = outerResultsDecoded.shift();
   const parsedVals = outerResultsDecoded.reduce((acc, r) => {
     r.forEach((results, idx) => {
+      if (results === '0x') {
+        acc.push(null);
+        return;
+      }
       const types = calls[idx].returnTypes;
       const resultsDecoded = decodeParameters(types, results);
       acc.push(


### PR DESCRIPTION
# Hack a decode issue of ethers abi-coder

for example 

```
{
  target: '0xa88aB555AE98Ed87E766c916159451523eDe7618',
  call: ['getReserves()(unit256,unit256)']
}

```
will get result ```0x```
the whole request will be error cause of one of the call gets Error from ethers abi-coder

just exclude the 0x

try catch to handle the abi-coder error is Another solution 